### PR TITLE
Avoid performing a type conversion

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -56,7 +56,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.objectClass = :objectClass";
         $dql .= " ORDER BY log.version DESC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass'));
 


### PR DESCRIPTION
`object_id` is of type `varchar`, whereas the parameter is passed as an integer. This forces MySQL to perform a type conversion from integer to string which has a performance impact in the SQL query.

Please, take a look at the following example where the `ext_log_entries` table had 37410 records.

![captura de pantalla 2017-11-15 a las 11 12 53](https://user-images.githubusercontent.com/337904/32830734-7965a572-c9f6-11e7-99e3-2a9d99e5e3e4.png)

![captura de pantalla 2017-11-15 a las 11 12 21](https://user-images.githubusercontent.com/337904/32830772-94d35520-c9f6-11e7-9d9e-bffe73c84071.png)

In the first image (with the changes proposed in this PR), the query is blazing fast whereas in the second (the code with no changes) it takes longer because of the performance impact to convert the integer into a string.

